### PR TITLE
Adding finite horizon extension method

### DIFF
--- a/src/LocalFunctionApproximation.jl
+++ b/src/LocalFunctionApproximation.jl
@@ -20,7 +20,8 @@ export
 	get_all_interpolating_values,
 	get_interpolating_nbrs_idxs_wts,
 	compute_value,
-	set_all_interpolating_values
+	set_all_interpolating_values,
+	finite_horizon_extension
 
 
 abstract type LocalFunctionApproximator end
@@ -70,6 +71,13 @@ function compute_value end
 Set the values of all interpolating points to the input vector
 """
 function set_all_interpolating_values end
+
+"""
+	finite_horizon_extension(lfa::LocalFunctionApproximator, hor::Int64)
+
+Extend the LFA appropriately along a new dimension to allow for finite-horizon approximations
+"""
+function finite_horizon_extension end
 
 
 include("local_gi_fa.jl")

--- a/src/local_gi_fa.jl
+++ b/src/local_gi_fa.jl
@@ -35,3 +35,10 @@ end
 function set_all_interpolating_values(gifa::LocalGIFunctionApproximator, gvalues::AbstractVector{Float64})
     gifa.gvalues = copy(gvalues)
 end
+
+function finite_horizon_extension(lfa::LocalFunctionApproximator, hor::StepRange{Int64,Int64})
+    cut_points = lfa.grid.cutPoints
+    extended_grid = RectangleGrid(cut_points..., hor)
+
+    return LocalGIFunctionApproximator(extended_grid)
+end


### PR DESCRIPTION
Extend the grid along an extra axis which represents discrete timesteps, up to a horizon limit parameter. Only applicable for grid interpolation and not nearest neighbor samples.